### PR TITLE
Replaced deprecated moodle api function

### DIFF
--- a/apply.php
+++ b/apply.php
@@ -16,11 +16,11 @@ require_once($CFG->dirroot.'/lib/outputcomponents.php');
 require_once ('lib.php');
 
 $site = get_site ();
-$systemcontext = get_context_instance ( CONTEXT_SYSTEM );
+$systemcontext = context_system::instance();
 
 $id = required_param ( 'id', PARAM_INT ); // course id
 $course = $DB->get_record ( 'course', array ('id' => $id ), '*', MUST_EXIST );
-$context = get_context_instance ( CONTEXT_COURSE, $course->id, MUST_EXIST );
+$context =  context_course::instance($course->id, MUST_EXIST);
 
 require_login ( $course );
 require_capability ( 'moodle/course:enrolreview', $context );

--- a/edit.php
+++ b/edit.php
@@ -17,7 +17,7 @@ $courseid   = required_param('courseid', PARAM_INT);
 $instanceid = optional_param('id', 0, PARAM_INT); // instanceid
 
 $course = $DB->get_record('course', array('id'=>$courseid), '*', MUST_EXIST);
-$context = get_context_instance(CONTEXT_COURSE, $course->id, MUST_EXIST);
+$context =  context_course::instance($course->id, MUST_EXIST);
 
 require_login($course);
 require_capability('enrol/self:config', $context);

--- a/enroluser.php
+++ b/enroluser.php
@@ -20,7 +20,7 @@ $extendbase   = optional_param('extendbase', 3, PARAM_INT);
 
 $instance = $DB->get_record('enrol', array('id'=>$enrolid, 'enrol'=>'apply'), '*', MUST_EXIST);
 $course = $DB->get_record('course', array('id'=>$instance->courseid), '*', MUST_EXIST);
-$context = get_context_instance(CONTEXT_COURSE, $course->id, MUST_EXIST);
+$context =  context_course::instance($course->id, MUST_EXIST);
 
 require_login($course);
 //require_capability('enrol/manual:enrol', $context);

--- a/lib.php
+++ b/lib.php
@@ -30,7 +30,7 @@ class enrol_apply_plugin extends enrol_plugin {
 	}
 
 	public function get_newinstance_link($courseid) {
-		$context = get_context_instance(CONTEXT_COURSE, $courseid, MUST_EXIST);
+		$context =  context_course::instance($courseid, MUST_EXIST);
 
 		if (!has_capability('moodle/course:enrolconfig', $context) or !has_capability('enrol/manual:config', $context)) {
 			return NULL;
@@ -114,7 +114,7 @@ class enrol_apply_plugin extends enrol_plugin {
 		if ($instance->enrol !== 'apply') {
 			throw new coding_exception('invalid enrol instance!');
 		}
-		$context = get_context_instance(CONTEXT_COURSE, $instance->courseid);
+		$context =  context_course::instance($instance->courseid);
 
 		$icons = array();
 
@@ -229,7 +229,7 @@ function sendConfirmMailToTeachers($courseid,$desc){
 	
 	if($apply_setting['sendmailtoteacher']->value == 1){
 		$course = $DB->get_record('course',array('id'=>$courseid));
-		$context = get_context_instance(CONTEXT_COURSE, $courseid, MUST_EXIST);
+		$context =  context_course::instance($courseid, MUST_EXIST);
 		$teacherType = $DB->get_record('role',array("shortname"=>"editingteacher"));
 		$teachers = $DB->get_records('role_assignments', array('contextid'=>$context->id,'roleid'=>$teacherType->id));
 		foreach($teachers as $teacher){

--- a/manage.php
+++ b/manage.php
@@ -15,7 +15,7 @@ require_login();
 require_capability('enrol/apply:manage', context_system::instance());
 
 $site = get_site ();
-$systemcontext = get_context_instance ( CONTEXT_SYSTEM );
+$systemcontext = context_system::instance();
 
 $PAGE->set_url ( '/enrol/manage.php');
 $PAGE->set_context($systemcontext);

--- a/unenroluser.php
+++ b/unenroluser.php
@@ -50,7 +50,7 @@ if ($course->id == SITEID) {
 // Obviously
 require_login($course);
 // Make sure the user can unenrol self enrolled users.
-require_capability("enrol/self:unenrol", get_context_instance(CONTEXT_COURSE, $course->id));
+require_capability("enrol/self:unenrol", context_course::instance($course->id));
 
 // Get the enrolment manager for this course
 $manager = new course_enrolment_manager($PAGE, $course, $filter);


### PR DESCRIPTION
Changes made by @jordif
Replaced deprecated function get_context_instance()
original request was #8, but splitted up by me into separate commits.
