### PR TITLE
Add more placeholders

### DIFF
--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -18,8 +18,8 @@ $string['confirmmailsubject'] = 'Confirm mail subject';
 $string['confirmmailcontent'] = 'Confirm mail content';
 $string['cancelmailsubject'] = 'Cancel mail subject';
 $string['cancelmailcontent'] = 'Cancel mail sontent';
-$string['confirmmailcontent_desc'] = 'Please use special marks designated email content replaced.<br>{firstname}:Registration name; {content}:Course name';
-$string['cancelmailcontent_desc'] = 'Please use special marks designated email content replaced.<br>{firstname}:Registration name; {content}:Course name';
+$string['confirmmailcontent_desc'] = 'Please use special marks designated email content replaced.<br>{firstname}:Registration name; {content}:Course name;{lastname}:The last name of the user;{username}:Registration name';
+$string['cancelmailcontent_desc'] = 'Please use special marks designated email content replaced.<br>{firstname}:Registration name; {content}:Course name;{lastname}:The last name of the user;{username}:Registration name';
 
 $string['confirmusers'] = 'Enrol Confirm';
 

--- a/lib.php
+++ b/lib.php
@@ -202,7 +202,7 @@ function sendCancelMail($info){
 	global $CFG;
 	$apply_setting = $DB->get_records_sql("select name,value from ".$CFG->prefix."config_plugins where plugin='enrol_apply'");
 
-	$replace = array('firstname'=>$info->firstname,'content'=>$info->coursename);
+	$replace = array('firstname'=>$info->firstname,'content'=>$info->coursename,'lastname'=>$info->lastname,'username'=>$info->username);
 	$body = $apply_setting['cancelmailcontent']->value;
 	$body = updateMailContent($body,$replace);
 	$contact = get_admin();
@@ -214,7 +214,7 @@ function sendConfirmMail($info){
 	global $CFG;
 	$apply_setting = $DB->get_records_sql("select name,value from ".$CFG->prefix."config_plugins where plugin='enrol_apply'");
 
-	$replace = array('firstname'=>$info->firstname,'content'=>$info->coursename);
+	$replace = array('firstname'=>$info->firstname,'content'=>$info->coursename,'lastname'=>$info->lastname,'username'=>$info->username);
 	$body = $apply_setting['confirmmailcontent']->value;
 	$body = updateMailContent($body,$replace);
 	$contact = get_admin();


### PR DESCRIPTION
In the confirmation/ cancelation mail can now be used the following placeholders:
{firstname} -> First name
{lastname} -> Last name
{username} -> username
{content} -> password
