### PR TITLE
Fix notification message type: success instead of error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -49,7 +49,7 @@ class enrol_apply_plugin extends enrol_plugin {
 		if ($DB->record_exists('user_enrolments', array('userid'=>$USER->id, 'enrolid'=>$instance->id))) {
 			//TODO: maybe we should tell them they are already enrolled, but can not access the course
 			//return null;
-			return $OUTPUT->notification(get_string('notification', 'enrol_apply'));
+			return $OUTPUT->notification(get_string('notification', 'enrol_apply'), 'notifysuccess');
 		}
 
 		if ($instance->enrolstartdate != 0 and $instance->enrolstartdate > time()) {


### PR DESCRIPTION
The notification type is incorrect. This is a success instead of an error here:
![notificationmessage](https://cloud.githubusercontent.com/assets/609386/9225082/2331a7ca-40d5-11e5-97f9-66dc970310dc.png)
