### PR TITLE
adding composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "emeneo/moodle-enrol_apply",
+    "description": "An enrol plugin for Moodle that adds an approval step into the course enrolment process.",
+    "type": "moodle-enrol",
+    "license": "GPLv3",
+    "require": {
+        "composer/installers": "*"
+    },
+    "extra": {
+        "installer-name": "apply"
+    }
+}

--- a/version.php
+++ b/version.php
@@ -22,3 +22,4 @@ $plugin->version  = 2015110300;
 $plugin->requires = 2011080100;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'Enrolment upon approval plugin Version 2.9-b';
+$plugin->component = 'enrol_apply';


### PR DESCRIPTION
Hello,

this adds the composer.json file so people can deploy your plugin
using the composer tool (https://getcomposer.org/).
Although it is not a Moodle standard or recommendation (yet), composer is largely used
and accepted tool in the PHP community.
If you have any questions, please take a look at the following links:

http://www.phptherightway.com/#composer_and_packagist
https://moodle.org/mod/forum/discuss.php?d=275466
https://tracker.moodle.org/browse/MDL-48114
https://moodle.org/mod/forum/discuss.php?d=312215

I've made some pull requests to plugins that I use and like
and that have their source on github and until this point
11 plugins have merged, 19 are pending (including this one)
and only 1 delayed until a definitive position from Moodle HQ.

Kind regards,
Daniel