### PR TITLE
Simple fix for moodle 3.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -21,4 +21,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->version  = 2015110300;
 $plugin->requires = 2011080100;
 $plugin->maturity = MATURITY_STABLE;
+$plugin->component = 'enrol_apply'
 $plugin->release = 'Enrolment upon approval plugin Version 2.9-b';


### PR DESCRIPTION
Moodle 3.0 requires a `$plugin->component` set in `version.php`. This changes does it.