### PR TITLE
Filter enrols

### DIFF
--- a/apply.php
+++ b/apply.php
@@ -22,6 +22,8 @@ $id = required_param ( 'id', PARAM_INT ); // course id
 $course = $DB->get_record ( 'course', array ('id' => $id ), '*', MUST_EXIST );
 $context =  context_course::instance($course->id, MUST_EXIST);
 
+$enrolid = optional_param('enrolid', 0, PARAM_INT);
+
 require_login ( $course );
 require_capability ( 'moodle/course:enrolreview', $context );
 
@@ -40,15 +42,15 @@ if (isset ( $_POST ['enrolid'] )) {
 		} elseif ($_POST ['type'] == 'cancel') {
 			cancelEnrolment ( $_POST ['enrolid'] );
 		}
-		redirect ( "$CFG->wwwroot/enrol/apply/apply.php?id=" . $id . "&enrolid=" . $_GET ['enrolid'] );
+		redirect ( "$CFG->wwwroot/enrol/apply/apply.php?id=" . $id . "&enrolid=" . $enrolid );
 	}
 }
 
-$enrols = getAllEnrolment ($id);
+$enrols = getAllEnrolment ($enrolid);
 
 echo $OUTPUT->header ();
 echo $OUTPUT->heading ( get_string ( 'confirmusers', 'enrol_apply' ) );
-echo '<form id="frmenrol" method="post" action="apply.php?id=' . $id . '&enrolid=' . $_GET ['enrolid'] . '">';
+echo '<form id="frmenrol" method="post" action="apply.php?id=' . $id . '&enrolid=' . $enrolid . '">';
 echo '<input type="hidden" id="type" name="type" value="confirm">';
 echo '<table class="generalbox editcourse boxaligncenter"><tr class="header">';
 echo '<th class="header" scope="col">&nbsp;</th>';

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "emeneo/moodle-enrol_apply",
+    "description": "An enrol plugin for Moodle that adds an approval step into the course enrolment process.",
+    "type": "moodle-enrol",
+    "license": "GPLv3",
+    "require": {
+        "composer/installers": "*"
+    },
+    "extra": {
+        "installer-name": "apply"
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -53,6 +53,15 @@ $capabilities = array(
         )
     ),
 
+    'enrol/apply:enrol' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => array(
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        )
+    ),
+
     'enrol/apply:unenrol' => array(
         'captype' => 'write',
         'contextlevel' => CONTEXT_COURSE,

--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -35,6 +35,7 @@ $string['status'] = 'Allow Course enrol confirmation';
 $string['confirmenrol'] = 'Manage application';
 
 $string['apply:config'] = 'Configure apply enrol instances';
+$string['apply:enrol'] = 'Enrol users';
 $string['apply:manage'] = 'Manage apply enrolment';
 $string['apply:unenrol'] = 'Cancel users from the course';
 $string['apply:unenrolapply'] = 'Cancel self from the course'; // is this necessary now?

--- a/lib.php
+++ b/lib.php
@@ -237,13 +237,32 @@ class enrol_apply_plugin extends enrol_plugin {
 	}
 }
 
-function getAllEnrolment($id = null){
+function getAllEnrolment($id = null) {
 	global $DB;
-	global $CFG;
-	if($id){
-		$userenrolments = $DB->get_records_sql('select ue.userid,ue.id,u.firstname,u.lastname,u.email,u.picture,c.fullname as course,ue.timecreated from '.$CFG->prefix.'user_enrolments as ue left join '.$CFG->prefix.'user as u on ue.userid=u.id left join '.$CFG->prefix.'enrol as e on ue.enrolid=e.id left join '.$CFG->prefix.'course as c on e.courseid=c.id where ue.status=1 and e.courseid='.$id);
-	}else{
-		$userenrolments = $DB->get_records_sql('select ue.id,ue.userid,u.firstname,u.lastname,u.email,u.picture,c.fullname as course,ue.timecreated from '.$CFG->prefix.'user_enrolments as ue left join '.$CFG->prefix.'user as u on ue.userid=u.id left join '.$CFG->prefix.'enrol as e on ue.enrolid=e.id left join '.$CFG->prefix.'course as c on e.courseid=c.id where ue.status=1');
+	if ($id) {
+            $sql = 'SELECT ue.userid,ue.id,u.firstname,u.lastname,u.email,u.picture,c.fullname as course,ue.timecreated
+                      FROM {course} c
+                      JOIN {enrol} e
+                        ON e.courseid = c.id
+                      JOIN {user_enrolments} ue
+                        ON ue.enrolid = e.id
+                      JOIN {user} u
+                        ON ue.userid = u.id
+                     WHERE ue.status = 1
+                       AND e.id = ?';
+            $userenrolments = $DB->get_records_sql($sql, array($id));
+	} else {
+            $sql = 'SELECT ue.id,ue.userid,u.firstname,u.lastname,u.email,u.picture,c.fullname as course,ue.timecreated
+                      FROM {user_enrolments} ue
+                 LEFT JOIN {user} u
+                        ON ue.userid = u.id
+                 LEFT JOIN {enrol} e
+                        ON ue.enrolid = e.id
+                 LEFT JOIN {course} c
+                        ON e.courseid = c.id
+                     WHERE ue.status = 1
+                       AND e.enrol = ?';
+            $userenrolments = $DB->get_records_sql($sql, array('apply'));
 	}
 	return $userenrolments;
 }


### PR DESCRIPTION
Hello,

this patch changes the SQL queries on getAllEnrolments to list only enrol for the plugin instance on apply.php and to list only enrols of the 'apply' plugin on manage.php (and also updates the coding style of the queries to Moodle's current standard).

It also adds a new capability that were missing and a new composer.json file to allow people to install the plugin using the composer dependency manager.

Kind regards,
Daniel