### PR TITLE
Change wording for confirm/cancel enrolment buttons.

### DIFF
--- a/lang/de/enrol_apply.php
+++ b/lang/de/enrol_apply.php
@@ -27,8 +27,8 @@ $string['coursename'] = 'Kurs';
 $string['applyuser'] = 'Voname / Nachname';
 $string['applyusermail'] = 'Email';
 $string['applydate'] = 'Einschreibungsdatum';
-$string['btnconfirm'] = 'Bestätigen';
-$string['btncancel'] = 'Abbruch';
+$string['btnconfirm'] = 'Einschreibungsanfragen bestätigen';
+$string['btncancel'] = ' Einschreibungsanfragen ablehnen';
 $string['enrolusers'] = 'Benutzer manuell einschreiben';
 
 $string['status'] = 'Bestätigung der Kurseinschreibung erlauben';

--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -27,8 +27,8 @@ $string['coursename'] = 'Course';
 $string['applyuser'] = 'First name / Surname';
 $string['applyusermail'] = 'Email';
 $string['applydate'] = 'Enrol date';
-$string['btnconfirm'] = 'Confirm';
-$string['btncancel'] = 'Cancel';
+$string['btnconfirm'] = 'Confirm requests';
+$string['btncancel'] = 'Cancel requests';
 $string['enrolusers'] = 'Enrol users';
 
 $string['status'] = 'Allow Course enrol confirmation';

--- a/lang/en_us/en_us_enrol_apply.php
+++ b/lang/en_us/en_us_enrol_apply.php
@@ -27,8 +27,8 @@ $string['coursename'] = 'Course';
 $string['applyuser'] = 'First name / Surname';
 $string['applyusermail'] = 'Email';
 $string['applydate'] = 'Enroll date';
-$string['btnconfirm'] = 'Confirm';
-$string['btncancel'] = 'Cancel';
+$string['btnconfirm'] = 'Confirm requests';
+$string['btncancel'] = 'Cancel requests';
 $string['enrollusers'] = 'Enroll users';
 
 $string['status'] = 'Allow course enroll confirmation';


### PR DESCRIPTION
Only changes de, en and en_us language.

The wording of the confirm/cancel buttons is ambiguous. "Cancel" could also mean "cancel the action of confirming/canceling enrolments"/"go back to the course page".