### PR TITLE
Notification improvements

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -16,16 +16,25 @@
 
 /**
  * @package    enrol_apply
- * @copyright  emeneo.com (http://emeneo.com/)
+ * @copyright  2016 sudile GbR (http://www.sudile.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author     Flotter Totte <flottertotte@emeneo.com>
  * @author     Johannes Burk <johannes.burk@sudile.com>
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2016060801;
-$plugin->requires = 2011080100;
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'Enrolment upon approval plugin Version 3.1-a';
-$plugin->component = 'enrol_apply';
+$messageproviders = array (
+    // Notify teacher/manager that a student has applied for a course enrolment.
+    'application' => array (
+        'capability'  => 'enrol/apply:manageapplications'
+    ),
+
+    // Notify student that his application was confirmed.
+    'confirmation' => array (),
+
+    // Notify student that his application was canceled.
+    'cancelation' => array (),
+
+    // Notify student that his application was deferred (put on a waiting list).
+    'waitinglist' => array (),
+);

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -67,6 +67,31 @@ function xmldb_enrol_apply_upgrade($oldversion) {
         }
     }
 
+    if ($oldversion < 2016060803) {
+        // Convert old notification settings.
+        $enrolapply = enrol_get_plugin('apply');
+
+        $sendmailtoteacher = $enrolapply->get_config('sendmailtoteacher');
+        $notifycoursebased = $sendmailtoteacher;
+        $enrolapply->set_config('notifycoursebased', $notifycoursebased);
+        $enrolapply->set_config('sendmailtoteacher', null);
+
+        $sendmailtomanager = $enrolapply->get_config('sendmailtomanager');
+        $notifyglobal = $sendmailtomanager ? '$@ALL@$' : '';
+        $enrolapply->set_config('notifyglobal', $notifyglobal);
+        $enrolapply->set_config('sendmailtomanager', null);
+
+        $instances = $DB->get_records('enrol', array('enrol' => 'apply'));
+        foreach ($instances as $instance) {
+            $sendmailtoteacher = $instance->customint3;
+            $notify = $sendmailtoteacher ? '$@ALL@$' : '';
+            $instance->customtext2 = $notify;
+            $instance->customint3 = null;
+            $instance->customint4 = null;
+            $DB->update_record('enrol', $instance, true);
+        }
+    }
+
     return true;
 
 }

--- a/edit.php
+++ b/edit.php
@@ -61,19 +61,39 @@ if ($instanceid) {
     $instance->courseid = $course->id;
 }
 
+// Process notify setting for editing...
+// Convert to array for use with multi-select element.
+$notify = array('$@NONE@$');
+if ($instance->customtext2 != '') {
+    $notify = explode(',', $instance->customtext2);
+}
+$instance->notify = $notify;
 $mform = new enrol_apply_edit_form(null, array($instance, $plugin, $context));
 
 if ($mform->is_cancelled()) {
     redirect($return);
 
 } else if ($data = $mform->get_data()) {
+    // Process notify setting for storing...
+    // Note: Mostly copied from admin_setting_users_with_capability::write_setting().
+    $notify = $data->notify;
+    // If all is selected, remove any explicit options.
+    if (in_array('$@ALL@$', $notify)) {
+        $notify = array('$@ALL@$');
+    }
+    // None never needs to be written to the DB.
+    if (in_array('$@NONE@$', $notify)) {
+        unset($notify[array_search('$@NONE@$', $notify)]);
+    }
+    // Convert back to string for storing in enrol table.
+    $data->customtext2 = implode(',', $notify);
     if ($instance->id) {
         $instance->status       = $data->status;
         $instance->name         = $data->name;
         $instance->customtext1  = $data->customtext1;
+        $instance->customtext2  = $data->customtext2;
         $instance->customint1   = $data->customint1;
         $instance->customint2   = $data->customint2;
-        $instance->customint3   = $data->customint3;
         $instance->roleid       = $data->roleid;
         $instance->timemodified = time();
         $DB->update_record('enrol', $instance);
@@ -85,8 +105,8 @@ if ($mform->is_cancelled()) {
             'roleid'      => $data->roleid,
             'customint1'  => $data->customint1,
             'customint2'  => $data->customint2,
-            'customint3'  => $data->customint3,
-            'customtext1' => $data->customtext1);
+            'customtext1' => $data->customtext1,
+            'customtext2' => $data->customtext2);
         $plugin->add_instance($course, $fields);
     }
 

--- a/edit_form.php
+++ b/edit_form.php
@@ -60,7 +60,15 @@ class enrol_apply_edit_form extends moodleform {
         $mform->addElement('select', 'customint2', get_string('show_extra_user_profile', 'enrol_apply'), $options);
         $mform->setDefault('customint2', $plugin->get_config('customint2'));
 
-        $mform->addElement('advcheckbox', 'customint3', get_string('sendmailtoteacher', 'enrol_apply'));
+        $choices = array(
+            '$@NONE@$' => get_string('nobody'),
+            '$@ALL@$' => get_string('everyonewhocan', 'admin', get_capability_string('enrol/apply:manageapplications')));
+        $users = get_enrolled_users($context, 'enrol/apply:manageapplications');
+        foreach ($users as $userid => $user) {
+            $choices[$userid] = fullname($user);
+        }
+        $select = $mform->addElement('select', 'notify', get_string('notify_desc', 'enrol_apply'), $choices);
+        $select->setMultiple(true);
 
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);

--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -50,8 +50,10 @@ $string['cancelmailcontent_desc'] = 'Please use the following special marks to r
 
 $string['notify_heading'] = 'Notification settings';
 $string['notify_desc'] = 'Define who gets notified about new enrolment applications.';
-$string['sendmailtoteacher'] = 'Send email notification to teachers';
-$string['sendmailtomanager'] = 'Send email notification to managers';
+$string['notifycoursebased'] = "New enrolment application notification (instance based, eg. course teachers)";
+$string['notifycoursebased_desc'] = "Default for new instances: Notify everyone who have the 'Manage apply enrolment' capability for the corresponding course (eg. teachers and managers)";
+$string['notifyglobal'] = "New enrolment application notification (global, eg. global managers and admins)";
+$string['notifyglobal_desc'] = "Define who gets notified about new enrolment applications for any course.";
 
 $string['messageprovider:application'] = 'Course enrolment application notifications';
 $string['messageprovider:confirmation'] = 'Course enrolment application confirmation notifications';

--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -53,6 +53,16 @@ $string['notify_desc'] = 'Define who gets notified about new enrolment applicati
 $string['sendmailtoteacher'] = 'Send email notification to teachers';
 $string['sendmailtomanager'] = 'Send email notification to managers';
 
+$string['messageprovider:application'] = 'Course enrolment application notifications';
+$string['messageprovider:confirmation'] = 'Course enrolment application confirmation notifications';
+$string['messageprovider:cancelation'] = 'Course enrolment application cancelation notifications';
+$string['messageprovider:waitinglist'] = 'Course enrolment application defer notifications';
+
+$string['newapplicationnotification'] = 'There is a new course enrolment application awaiting review.';
+$string['applicationconfirmednotification'] = 'Your course enrolment application was confirmed.';
+$string['applicationcancelednotification'] = 'Your course enrolment application was canceled.';
+$string['applicationdeferrednotification'] = 'Your course enrolment application was deferred (you are currently on the waiting list).';
+
 $string['confirmusers'] = 'Enrol Confirm';
 $string['confirmusers_desc'] = 'Users in gray colored rows are on the waiting list.';
 

--- a/notification.php
+++ b/notification.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    enrol_apply
+ * @copyright  2016 sudile GbR (http://www.sudile.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Johannes Burk <johannes.burk@sudile.com>
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+class enrol_apply_notification extends \core\message\message {
+    public function __construct($to, $from, $type, $subject, $content, $url) {
+        $this->component = 'enrol_apply';
+
+        switch ($type) {
+            case 'application':
+                $this->name = 'application';
+                $this->smallmessage = get_string('newapplicationnotification', 'enrol_apply');
+                break;
+            case 'confirmation':
+                $this->name = 'confirmation';
+                $this->smallmessage = get_string('applicationconfirmednotification', 'enrol_apply');
+                break;
+            case 'cancelation':
+                $this->name = 'cancelation';
+                $this->smallmessage = get_string('applicationcancelednotification', 'enrol_apply');
+                break;
+            case 'waitinglist':
+                $this->name = 'waitinglist';
+                $this->smallmessage = get_string('applicationdeferrednotification', 'enrol_apply');
+                break;
+            default:
+                throw new invalid_parameter_exception('Invalid enrol_apply notification type.');
+                break;
+        }
+
+        $this->userfrom = $from;
+        $this->userto = $to;
+
+        $this->subject = $subject;
+        $this->fullmessage = html_to_text($content);
+        $this->fullmessageformat = FORMAT_PLAIN;
+        $this->fullmessagehtml = $content;
+
+        $this->notification = true;
+        $this->contexturl = $url;
+        $this->contexturlname = get_string('course');
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -90,16 +90,12 @@ if ($ADMIN->fulltree) {
         'enrol_apply_notify',
         get_string('notify_heading', 'enrol_apply'),
         get_string('notify_desc', 'enrol_apply')));
-    $settings->add(new admin_setting_configcheckbox(
-        'enrol_apply/sendmailtoteacher',
-        get_string('sendmailtoteacher', 'enrol_apply'),
-        '',
-        0));
-    $settings->add(new admin_setting_configcheckbox(
-        'enrol_apply/sendmailtomanager',
-        get_string('sendmailtomanager', 'enrol_apply'),
-        '',
-        0));
+    $settings->add(new admin_setting_users_with_capability(
+        'enrol_apply/notifyglobal',
+        get_string('notifyglobal', 'enrol_apply'),
+        get_string('notifyglobal_desc', 'enrol_apply'),
+        array(),
+        'enrol/apply:manageapplications'));
 
     // Enrol instance defaults...
     $settings->add(new admin_setting_heading('enrol_manual_defaults',
@@ -130,6 +126,12 @@ if ($ADMIN->fulltree) {
         $settings->add(new admin_setting_configselect('enrol_apply/roleid',
             get_string('defaultrole', 'role'), '', $student->id, $options));
     }
+
+    $settings->add(new admin_setting_configcheckbox(
+        'enrol_apply/notifycoursebased',
+        get_string('notifycoursebased', 'enrol_apply'),
+        get_string('notifycoursebased_desc', 'enrol_apply'),
+        0));
 }
 
 if ($hassiteconfig) { // Needs this condition or there is error on login page.

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2016060801;
+$plugin->version  = 2016060803;
 $plugin->requires = 2011080100;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'Enrolment upon approval plugin Version 3.1-a';


### PR DESCRIPTION
- Use Messaging API instead of email_to_user() function
- Change notification settings and behaviour.
  - Replace global 'sendmailtoteacher' setting (checkbox) by 'notifycoursebased' (checkbox): default for new instances
  - Replace global 'sendmailtomanager' setting (checkbox) by 'notifyglobal' (multi-select): user based selection (users with 'manageapplications' capability in system context)
  - Replace instance notification setting (checkbox) by user based selection (multi-select): enrolled users with 'manageapplications' capability in course context
  - Upgrade process:
    - if 'sendmailtoteacher' was true, set 'notifycoursebased' true
    - if 'sendmailtomanager' was true, set 'notifyglobal' to "Everyone who can 'Manage apply enrolment'", "Nobody" otherwise
    - if instance based notification setting was set to true, set new user based setting to "Everyone who can 'Manage apply enrolment'", "Nobody" otherwise
