### PR TITLE
Disable new enrols

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -102,6 +102,14 @@ function xmldb_enrol_apply_upgrade($oldversion) {
         }
     }
 
+    if ($oldversion < 2018112603) {
+        $instances = $DB->get_records('enrol', array('enrol' => 'apply'));
+        foreach ($instances as $instance) {
+            $instance->customint6 = 1;
+            $DB->update_record('enrol', $instance, true);
+        }
+    }
+
     return true;
 
 }

--- a/edit.php
+++ b/edit.php
@@ -95,6 +95,7 @@ if ($mform->is_cancelled()) {
         $instance->customint1       = $data->customint1;
         $instance->customint2       = $data->customint2;
         $instance->customint3       = $data->customint3;
+        $instance->customint6       = $data->customint6;
         $instance->roleid           = $data->roleid;
         $instance->enrolperiod      = $data->enrolperiod;
         $instance->timemodified = time();
@@ -107,6 +108,7 @@ if ($mform->is_cancelled()) {
             'customint1'        => $data->customint1,
             'customint2'        => $data->customint2,
             'customint3'        => $data->customint3,
+            'customint6'        => $data->customint6,
             'customtext1'       => $data->customtext1,
             'customtext2'       => $data->customtext2,
             'enrolperiod'       => $data->enrolperiod

--- a/edit_form.php
+++ b/edit_form.php
@@ -44,6 +44,12 @@ class enrol_apply_edit_form extends moodleform {
         // $mform->addHelpButton('status', 'status', 'enrol_apply');
         $mform->setDefault('status', $plugin->get_config('status'));
 
+        $mform->addElement('select', 'customint6', get_string('newenrols', 'enrol_apply'), array(
+                1 => get_string('yes'),
+                0 => get_string('no')
+        ));
+        $mform->setDefault('newenrols', $plugin->get_config('newenrols'));
+
         if ($instance->id) {
             $roles = get_default_enrol_roles($context, $instance->roleid);
         } else {

--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -78,7 +78,7 @@ $string['btncancel'] = 'Cancel requests';
 $string['enrolusers'] = 'Enrol users';
 
 $string['status'] = 'Allow Course enrol confirmation';
-$string['newenrols'] = 'Allow new course enrol confirmation';
+$string['newenrols'] = 'Allow new course enrol appliance';
 $string['confirmenrol'] = 'Manage application';
 
 $string['apply:config'] = 'Configure apply enrol instances';

--- a/lang/en/enrol_apply.php
+++ b/lang/en/enrol_apply.php
@@ -78,6 +78,7 @@ $string['btncancel'] = 'Cancel requests';
 $string['enrolusers'] = 'Enrol users';
 
 $string['status'] = 'Allow Course enrol confirmation';
+$string['newenrols'] = 'Allow new course enrol confirmation';
 $string['confirmenrol'] = 'Manage application';
 
 $string['apply:config'] = 'Configure apply enrol instances';
@@ -103,6 +104,8 @@ $string['maxenrolled'] = 'Max enrolled users';
 $string['maxenrolled_help'] = 'Specifies the maximum number of users that can self enrol. 0 means no limit.';
 $string['maxenrolledreached_left'] = 'Maximum number of users allowed';
 $string['maxenrolledreached_right'] = 'has already been reached.';
+
+$string['cantenrol'] = 'Enrolment is disabled or inactive';
 
 $string['maxenrolled_tip_1'] = 'out of';
 $string['maxenrolled_tip_2'] = 'seats already booked.';

--- a/lib.php
+++ b/lib.php
@@ -45,6 +45,17 @@ class enrol_apply_plugin extends enrol_plugin {
         // Users may tweak the roles later.
         return false;
     }
+
+    public function allow_apply(stdClass $instance) {
+        if ($instance->status != ENROL_INSTANCE_ENABLED) {
+            return get_string('cantenrol', 'enrol_apply');
+        }
+        if (!$instance->customint6) {
+            // New enrols not allowed.
+            return get_string('cantenrol', 'enrol_apply');
+        }
+        return true;
+    }
     /**
      * Prevent to unenrol an user with a pending application
      *
@@ -85,6 +96,12 @@ class enrol_apply_plugin extends enrol_plugin {
             // Can not enrol guest!
             return null;
         }
+
+        $allowapply = $this->allow_apply($instance);
+        if ($allowapply !== true) {
+            return '<div class="alert alert-error">' . $allowapply . '</div>';
+        }
+
         if ($DB->record_exists('user_enrolments', array('userid' => $USER->id, 'enrolid' => $instance->id))) {
             return $OUTPUT->notification(get_string('notification', 'enrol_apply'), 'notifysuccess');
         }

--- a/settings.php
+++ b/settings.php
@@ -125,6 +125,10 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('enrol_apply/status',
         get_string('status', 'enrol_apply'), get_string('status_desc', 'enrol_apply'), ENROL_INSTANCE_ENABLED, $options));
 
+    $options = array(1 => get_string('yes'), 0 => get_string('no'));
+    $settings->add(new admin_setting_configselect('enrol_apply/newenrols',
+        get_string('status', 'enrol_apply'), get_string('status_desc', 'enrol_apply'), 1, $options));
+
     $options = array(1 => get_string('yes'),
                      0  => get_string('no'));
     $settings->add(new admin_setting_configselect('enrol_apply/show_standard_user_profile',

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2018051500;
+$plugin->version  = 2018112603;
 $plugin->requires = 2011080100;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'Enrolment upon approval plugin Version 3.5-a';


### PR DESCRIPTION
Adds an option to disable new appliances to an enrol_apply instance so that new users cannot apply but already enroled users keep their access to the course.