### PR TITLE
Notification fix

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -63,13 +63,13 @@ if ($instanceid) {
 
 // Process notify setting for editing...
 // Convert to array for use with multi-select element.
-$notify = array('$@NONE@$');
+//$notify = array('$@NONE@$');
 /*
 if ($instance->customtext2 != '') {
     $notify = explode(',', $instance->customtext2);
 }
 */
-$instance->notify = $notify;
+//$instance->notify = $notify;
 
 $mform = new enrol_apply_edit_form(null, array($instance, $plugin, $context));
 
@@ -91,10 +91,12 @@ if ($mform->is_cancelled()) {
     // Convert back to string for storing in enrol table.
     //$data->customtext2 = implode(',', $notify);
     if ($instance->id) {
+        $notify = implode(",", $notify);
         $instance->status           = $data->status;
         $instance->name             = $data->name;
         $instance->customtext1      = $data->customtext1;
         $instance->customtext2      = $data->customtext2;
+        $instance->customtext3      = $notify;
         $instance->customint1       = $data->customint1;
         $instance->customint2       = $data->customint2;
         $instance->customint3       = $data->customint3;

--- a/edit_form.php
+++ b/edit_form.php
@@ -29,6 +29,7 @@ require_once($CFG->libdir.'/formslib.php');
 class enrol_apply_edit_form extends moodleform {
 
     protected function definition() {
+        global $DB;
         $mform = $this->_form;
 
         list($instance, $plugin, $context) = $this->_customdata;
@@ -84,6 +85,19 @@ class enrol_apply_edit_form extends moodleform {
         }
         $select = $mform->addElement('select', 'notify', get_string('notify_desc', 'enrol_apply'), $choices);
         $select->setMultiple(true);
+        $userid = $DB->get_field('enrol', 'customtext3', array('id' => $instance->id), IGNORE_MISSING);
+        if(!empty($userid)) {
+            if($userid == '$@ALL@$') {
+                $select->setSelected('$@ALL@$');
+            }
+            else if($userid == '$@NONE@$') {
+                $select->setSelected('$@NONE@$');
+            }
+            else {
+                $userid = explode(",", $userid);
+                $select->setSelected($userid);
+            }
+        }
 
         $mform->addElement('text', 'customint3', get_string('maxenrolled', 'enrol_apply'));
         $mform->setType('customint3', PARAM_INT);

--- a/lib.php
+++ b/lib.php
@@ -397,8 +397,7 @@ class enrol_apply_plugin extends enrol_plugin {
         $renderer = $PAGE->get_renderer('enrol_apply');
         
         $course = get_course($instance->courseid);
-        $user = core_user::get_user($userid);
-        $contact = core_user::get_support_user();
+        $applicant = core_user::get_user($userid);
 
         // Include standard user profile fields?
         $standarduserfields = null;
@@ -411,8 +410,8 @@ class enrol_apply_plugin extends enrol_plugin {
         $extrauserfields = null;
         if ($instance->customint2) {
             require_once($CFG->dirroot.'/user/profile/lib.php');
-            profile_load_custom_fields($user);
-            $extrauserfields = $user->profile;
+            profile_load_custom_fields($applicant);
+            $extrauserfields = $applicant->profile;
         }
 
         // Send notification to users with manageapplications in course context (instance depending)?
@@ -421,7 +420,7 @@ class enrol_apply_plugin extends enrol_plugin {
             $manageurl = new moodle_url("/enrol/apply/manage.php", array('id' => $instance->id));
             $content = $renderer->application_notification_mail_body(
                 $course,
-                $user,
+                $applicant,
                 $manageurl,
                 $data->applydescription,
                 $standarduserfields,
@@ -429,7 +428,7 @@ class enrol_apply_plugin extends enrol_plugin {
             foreach ($courseuserstonotify as $user) {
                 $message = new enrol_apply_notification(
                     $user,
-                    $contact,
+                    $applicant,
                     'application',
                     get_string('mailtoteacher_suject', 'enrol_apply'),
                     $content,
@@ -448,7 +447,7 @@ class enrol_apply_plugin extends enrol_plugin {
             $manageurl = new moodle_url('/enrol/apply/manage.php');
             $content = $renderer->application_notification_mail_body(
                 $course,
-                $user,
+                $applicant,
                 $manageurl,
                 $data->applydescription,
                 $standarduserfields,
@@ -456,7 +455,7 @@ class enrol_apply_plugin extends enrol_plugin {
             foreach ($globaluserstonotify as $user) {
                 $message = new enrol_apply_notification(
                     $user,
-                    $contact,
+                    $applicant,
                     'application',
                     get_string('mailtoteacher_suject', 'enrol_apply'),
                     $content,
@@ -475,7 +474,7 @@ class enrol_apply_plugin extends enrol_plugin {
      * @return array           Array of user IDs.
      */
     public function get_notifycoursebased_users($instance) {
-        $value = $instance->customtext2;
+        $value = $instance->customtext3;
         if (empty($value) or $value === '$@NONE@$') {
             return array();
         }
@@ -508,7 +507,7 @@ class enrol_apply_plugin extends enrol_plugin {
      * @return array Array of user IDs.
      */
     public function get_notifyglobal_users() {
-        return get_users_from_config($this->get_config('notifyglobal'), 'enrol/apply:manageapplications');
+        return get_users_from_config($this->get_config('notifyglobal'), 'enrol/apply:manageapplications', false);
     }
 
     private function update_mail_content($content, $course, $user, $userenrolment) {


### PR DESCRIPTION
**edit.php**
1. In the instance setting, the choice for users who should receive the application notification would not save into database.
a.	_Solution: Save the users to table enrol->customtext3._

**edit-form.php**
1.	In the instance setting, users who selected to receive the application notification would not set as selected (may confusing people).
a.	_Solution: Query to table ‘enrol’ and the selected users as selected._

**lib.php**
1.	Users with ‘enrol/apply:manageapplications’ capability would not receive enrollment application notification.
a.	Sender and receiver share the same variable ($user) in send_application_notification()
b.	The sender in send_application_notification() is set to $contact, which assigned to user with ‘enrol/apply:manageapplications’.
2.	Variable $value in get_notifycoursebased_users() is assigned to $instance->customtext2, while customtext2 is the Custom Label. Therefore, this function would not return the user should receive application notification.
a.	_Solution: change customtext2 to custometext3._
3.	Admin will receive two notification from one application.
a.	get_users_from_config() in get_notifyglobal_users() without a ‘false’ in third parameter.
b.	_Solution: add ‘false’ to third parameter._

Test on: Moodle v3.6.2+ (build 20190118)