### PR TITLE
select users with capability not only enrolled

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -60,26 +60,30 @@ class enrol_apply_edit_form extends moodleform {
         $mform->setDefault('roleid', $plugin->get_config('roleid'));
 
         $mform->addElement('textarea', 'customtext1', get_string('editdescription', 'enrol_apply'));
+        $mform->setType('customtext1', PARAM_TEXT);
 
         //new added requirement_20190110
         //$title_customtext2 = str_replace("{replace_title}",$instance->customtext2,get_string('custom_label', 'enrol_apply'));
         $title_customtext2 = get_string('custom_label', 'enrol_apply');
         $mform->addElement('text', 'customtext2', $title_customtext2);
         $mform->setDefault('customtext2', "Comment");
+        $mform->setType('customtext2', PARAM_TEXT);
 
         $options = array(1 => get_string('yes'),
                          0 => get_string('no'));
 
         $mform->addElement('select', 'customint1', get_string('show_standard_user_profile', 'enrol_apply'), $options);
         $mform->setDefault('customint1', $plugin->get_config('customint1'));
+        $mform->setType('customint1', PARAM_INT);
 
         $mform->addElement('select', 'customint2', get_string('show_extra_user_profile', 'enrol_apply'), $options);
         $mform->setDefault('customint2', $plugin->get_config('customint2'));
+        $mform->setType('customint2', PARAM_INT);
 
         $choices = array(
             '$@NONE@$' => get_string('nobody'),
             '$@ALL@$' => get_string('everyonewhocan', 'admin', get_capability_string('enrol/apply:manageapplications')));
-        $users = get_enrolled_users($context, 'enrol/apply:manageapplications');
+        $users = get_users_by_capability($context, 'enrol/apply:manageapplications');
         foreach ($users as $userid => $user) {
             $choices[$userid] = fullname($user);
         }

--- a/lib.php
+++ b/lib.php
@@ -467,7 +467,7 @@ class enrol_apply_plugin extends enrol_plugin {
     }
 
     /**
-     * Returns enrolled users of a course who should be notified about new course enrolment applications.
+     * Returns users of a course who should be notified about new course enrolment applications.
      *
      * Note: mostly copied from get_users_from_config() function in moodlelib.php.
      * @param  array $instance Enrol apply instance record.
@@ -484,7 +484,7 @@ class enrol_apply_plugin extends enrol_plugin {
         // We have to make sure that users still have the necessary capability,
         // it should be faster to fetch them all first and then test if they are present
         // instead of validating them one-by-one.
-        $users = get_enrolled_users($context, 'enrol/apply:manageapplications');
+        $users = get_users_by_capability($context, 'enrol/apply:manageapplications');
 
         if ($value === '$@ALL@$') {
             return $users;


### PR DESCRIPTION
Hi,

this change make possible for non-enrolled users to be selected to be notified even if they are not enrolled on the course.
Many times managers are assigned global roles (or category roles) and are not enrolled on courses. With this change, they'll appear on the list to be notified.