### PR TITLE
removed not needed check for existing database entry

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -64,10 +64,6 @@ class enrol_apply_plugin extends enrol_plugin {
      * @return bool
      */
     public function allow_unenrol_user(stdClass $instance, stdClass $ue) {
-        global $DB;
-        if ($DB->record_exists('enrol_apply_applicationinfo', ['userenrolmentid' => $ue->id])) {
-            return false;
-        }
         return parent::allow_unenrol_user($instance, $ue);
     }
     public function allow_manage(stdClass $instance) {


### PR DESCRIPTION
Removed not needed check for existing database entry (solves https://github.com/emeneo/moodle-enrol_apply/issues/93 ), maybe even the opposit is needed (delete of existing entry?)