### PR TITLE
Clean up mixup of customtext2 and customtext3 fields (for fresh installations only)

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -85,7 +85,7 @@ function xmldb_enrol_apply_upgrade($oldversion) {
         foreach ($instances as $instance) {
             $sendmailtoteacher = $instance->customint3;
             $notify = $sendmailtoteacher ? '$@ALL@$' : '';
-            $instance->customtext2 = $notify;
+            $instance->customtext3 = $notify;
             $instance->customint3 = null;
             $instance->customint4 = null;
             $DB->update_record('enrol', $instance, true);

--- a/edit.php
+++ b/edit.php
@@ -65,8 +65,8 @@ if ($instanceid) {
 // Convert to array for use with multi-select element.
 //$notify = array('$@NONE@$');
 /*
-if ($instance->customtext2 != '') {
-    $notify = explode(',', $instance->customtext2);
+if ($instance->customtext3 != '') {
+    $notify = explode(',', $instance->customtext3);
 }
 */
 //$instance->notify = $notify;
@@ -89,7 +89,7 @@ if ($mform->is_cancelled()) {
         unset($notify[array_search('$@NONE@$', $notify)]);
     }
     // Convert back to string for storing in enrol table.
-    //$data->customtext2 = implode(',', $notify);
+    //$data->customtext3 = implode(',', $notify);
     $notify = implode(",", $notify);
 
     if ($instance->id) {

--- a/lib.php
+++ b/lib.php
@@ -292,7 +292,8 @@ class enrol_apply_plugin extends enrol_plugin {
         $fields['roleid']          = $this->get_config('roleid', 0);
         $fields['customint1']      = $this->get_config('show_standard_user_profile');
         $fields['customint2']      = $this->get_config('show_extra_user_profile');
-        $fields['customtext2']     = $this->get_config('notifycoursebased') ? '$@ALL@$' : '';
+        $fields['customtext2']     = '';
+        $fields['customtext3']     = $this->get_config('notifycoursebased') ? '$@ALL@$' : '';
         $fields['enrolperiod']     = $this->get_config('enrolperiod', 0);
         $fields['customint3']      = $this->get_config('maxenrolled');
         $fields['customint4']      = $this->get_config('sendcoursewelcomemessage');


### PR DESCRIPTION
In previous commits in this plugin, a mixup of the customtext2 and customtext3 fields was introduced and never cleaned up since then.
https://github.com/emeneo/moodle-enrol_apply/issues/89 dealt with the fact that a DB upgrade step was missing and came to a preliminary end with the conclusion that admins should fix existing data manually when upgrading the plugin.

However, the plugin is still broken for fresh installations as well. This is because the existing code still pre-fills customtext2 with notification settings, but reads the custom label from there. As a teacher adding an enrolment instance to a course, I see the 'Custom label' field filled with '$@ALL@$' which not really makes sense.

This patch tries to clean up this mixup so that at least fresh installations (and installations where the admin has cleaned up the data manually) work well again.