### PR TITLE
Send notification to users with manageapplications in course context

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -493,6 +493,7 @@ class enrol_apply_plugin extends enrol_plugin {
                     $content,
                     $manageurl,
                     $instance->courseid);
+                message_send($message);
             }
         }
 


### PR DESCRIPTION
Hello,
When the code was changed to use Notifications API, the message to users in course context was never sent.
It was missing a call to message_send like the other parts have.
Best,
Daniel